### PR TITLE
Show placeholder when product image is absent

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || "/placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

This PR fixes the bug where the image is broken when the product is created without an image.

Fixes #2.

# Screenshots

![Screenshot 2022-11-19 at 00-20-56 Anythink Market](https://user-images.githubusercontent.com/33974134/202753112-433b12e7-e8ab-4d5b-a744-877065b2ee20.png)
![Screenshot 2022-11-19 at 00-21-07 Anythink Market](https://user-images.githubusercontent.com/33974134/202753143-1be89f55-78c2-4236-ad42-035f3823b811.png)
